### PR TITLE
fix CR cleaned up too early

### DIFF
--- a/pkg/controllers/cluster.go
+++ b/pkg/controllers/cluster.go
@@ -426,8 +426,7 @@ func (c *Operate) ekshandler(clust *v1.Cluster) (rerr error) {
 			return err
 		}
 		klog.Infof("delete pvc in cluster %v success", clust.Name)
-		removecr = true
-		return nil
+		delete(clust.Annotations, AnnotationPvcGcLabelKey)
 	}
 	c.mgmu.Lock()
 	_, ok := c.magnums[spec.ClusterID]

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -105,6 +105,10 @@ func (r *Reconciler) doUpdateVmCrdStatus(nsname types.NamespacedName, newcl *v1.
 			klog.Errorf("get object %s failed:%v", nsname.String(), err)
 			return err
 		}
+		if !reflect.DeepEqual(original.Annotations, newcl.Annotations) {
+			original.Annotations = newcl.Annotations
+			isup = true
+		}
 		if !reflect.DeepEqual(original.Spec, newcl.Spec) {
 			newcl.Spec.DeepCopyInto(&original.Spec)
 			isup = true


### PR DESCRIPTION
CR will be deleted when pvc have been cleaned up, but cluster is still in the process of `DELETE`

Closes-Bug: #EAS-71162