### PR TITLE
Add `eks_creation_time` to `EksSpec`

### DIFF
--- a/pkg/api/v1/cluster_types.go
+++ b/pkg/api/v1/cluster_types.go
@@ -77,13 +77,14 @@ type ClusterSpec struct {
 }
 
 type EksSpec struct {
-	EksName          string            `json:"eks_name,omitempty"`
-	EksClusterID     string            `json:"eks_clusterid,omitempty"`
-	APIAddress       string            `json:"api_address,omitempty"`
-	EksStatus        string            `json:"eks_status,omitempty"`
-	EksReason        string            `json:"eks_reason,omitempty"`
-	EksStackID       string            `json:"eks_stackid,omitempty"`
-	EksHealthReasons map[string]string `json:"eks_health_reasons,omitempty"`
+	EksName           string            `json:"eks_name,omitempty"`
+	EksClusterID      string            `json:"eks_clusterid,omitempty"`
+	APIAddress        string            `json:"api_address,omitempty"`
+	EksStatus         string            `json:"eks_status,omitempty"`
+	EksReason         string            `json:"eks_reason,omitempty"`
+	EksStackID        string            `json:"eks_stackid,omitempty"`
+	CreationTimestamp int64             `json:"eks_creation_timestamp,omitempty"`
+	EksHealthReasons  map[string]string `json:"eks_health_reasons,omitempty"`
 
 	Hadsync bool `json:"-"`
 }

--- a/pkg/controllers/cluster.go
+++ b/pkg/controllers/cluster.go
@@ -147,6 +147,7 @@ func (c *Operate) mgFilter(page pagination.Page) {
 				neweks.EksName = info.Name
 				neweks.APIAddress = info.APIAddress
 				neweks.EksStackID = info.StackID
+				neweks.CreationTimestamp = info.CreatedAt.Unix()
 				if info.HealthStatusReason != nil {
 					for k, v := range info.HealthStatusReason {
 						if s, ok := v.(string); ok {


### PR DESCRIPTION
obtain creation time from Magnum rather than `creationTimestamp` in `metadata` of CR.

Closes-Bug: #EAS-70849