### PR TITLE
Fix volumes associated with the PVC deleted failed

### DIFF
--- a/pkg/controllers/cluster.go
+++ b/pkg/controllers/cluster.go
@@ -218,6 +218,7 @@ func (c *Operate) cinderDeleteFn(page pagination.Page) {
 		}
 	}
 	for id, ids := range dels {
+		klog.Infof("There are %d volumes associated with the PVC under cluster %s need to be deleted", len(dels[id]), id)
 		var (
 			errBuf    = utils.GetBuf()
 			newcinder = &removeCinder{
@@ -387,14 +388,14 @@ func (c *Operate) pvcReclaim(clust *v1.Cluster) error {
 	v, ok := c.cinders[spec.ClusterID]
 	if !ok {
 		c.cinders[spec.ClusterID] = &removeCinder{}
-		return fmt.Errorf("wait delete volume")
+		return fmt.Errorf("wait delete volume under cluster %s", spec.ClusterID)
 	}
 	if v.sync {
 		//try delete again, util success
 		v.sync = false
 		return v.status
 	}
-	return fmt.Errorf("wait delete volume")
+	return fmt.Errorf("wait delete volume under cluster %s", spec.ClusterID)
 }
 
 func (c *Operate) ekshandler(clust *v1.Cluster) (rerr error) {

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -67,7 +67,7 @@ func (or OpResource) ListPages(pv *gophercloud.ProviderClient) (pagination.Pager
 		if err != nil {
 			return pagination.Pager{}, err
 		}
-		return volumes.List(cli, volumes.ListOpts{}), nil
+		return volumes.List(cli, volumes.ListOpts{AllTenants: true}), nil
 	case Lb:
 		cli, err := openstack.NewNetworkV2(pv, gophercloud.EndpointOpts{})
 		if err != nil {


### PR DESCRIPTION
To the permission of cluster manager, volumes that need to be deleted are not accessible. Need option `all_tenants` to access.

Closes-Bug: #EAS-72120