### PR TITLE
Add `Timeout` option to Kubernetes Client

### DIFF
--- a/pkg/k8s/manage.go
+++ b/pkg/k8s/manage.go
@@ -168,6 +168,7 @@ func (s *Manage) newClient(host string) (cli.Client, error) {
 		BearerToken: token,
 		Transport:   defaultTransport,
 		Burst:       3,
+		Timeout:     30 * time.Second,
 	}
 	return cli.New(config, clioption)
 }


### PR DESCRIPTION
Request too long to an unaccessible apiserver.

Closes-Bug: #EAS-72212