### PR TITLE
Modify timeout of request to kube-apiserver

### DIFF
--- a/pkg/k8s/manage.go
+++ b/pkg/k8s/manage.go
@@ -169,7 +169,7 @@ func (s *Manage) newClient(host string) (cli.Client, error) {
 		BearerToken: token,
 		Transport:   defaultTransport,
 		Burst:       3,
-		Timeout:     30 * time.Second,
+		Timeout:     60 * time.Second,
 	}
 	return cli.New(config, clioption)
 }


### PR DESCRIPTION
Modify timeout 30s to 60s.